### PR TITLE
some enhancements

### DIFF
--- a/Sources/ComboColorWell/ComboColorWell.swift
+++ b/Sources/ComboColorWell/ComboColorWell.swift
@@ -295,7 +295,7 @@ class ComboColorWellCell: NSActionCell {
         // clip to fill the color area
         NSBezierPath.clip(colorArea(withFrame: cellFrame))
 
-        if color == .clear {
+        if color.alphaComponent < 1 {
             // want a diagonal black & white split
             // start filling all white
             fill(path: path, withColor: .white)
@@ -319,9 +319,10 @@ class ComboColorWellCell: NSActionCell {
             path.addClip()
             // finally draw the black portion
             fill(path: blackPath, withColor: .black)
-        } else {
-            fill(path: path, withColor: color)
         }
+        
+        fill(path: path, withColor: color)
+        
         
         // reset the clipping area
         path.setClip()
@@ -477,6 +478,7 @@ class ComboColorWellCell: NSActionCell {
             if colorPanel.isVisible,
                 colorPanel.delegate === self {
                 colorPanel.delegate = nil
+                colorPanel.close()
             }
         case .on:
             if let window = controlView?.window,


### PR DESCRIPTION
1. Should the user select a color of alpha less than 1, the triangle background is still drawn
<img width="592" alt="Screenshot 2022-02-13 at 5 22 52 PM" src="https://user-images.githubusercontent.com/23420208/153746873-c43e35d0-f5c3-4a73-b215-0f4ae20f06fe.png">

2. If the user clicks on the right side color wheel button, the panel also dismisses.