### PR TITLE
Fix render issue for macOS Sonoma 14.x users

### DIFF
--- a/Sources/ComboColorWell/ComboColorWell.swift
+++ b/Sources/ComboColorWell/ComboColorWell.swift
@@ -923,6 +923,7 @@ class ColorView: NSView {
         self.color = color
         self.colorGridView = colorGridView
         super.init(frame: NSZeroRect) // NSRect(origin: NSPoint(x: 0, y: 0), size: NSSize(width: 50, height: 30)))
+        self.clipsToBounds = true
     }
     
     required init?(coder decoder: NSCoder) {


### PR DESCRIPTION
Issue explained in #4. Fix #4 

Issue is due to `clipsToBounds` now defaulting to `false` rather than `true`. (Reference: https://developer.apple.com/documentation/appkit/nsview/4236466-clipstobounds).

Fix is simple, by setting `clipsToBounds` to true. Since that this property has been around for a long time, this should not impact pre-macOS 14.x users.